### PR TITLE
Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/display/index.html
+++ b/src/display/index.html
@@ -8,5 +8,5 @@
     quibusdam dignissimos laudantium facilis autem, praesentium iste non velit officia ipsam ipsum,
     officiis accusantium quod quia voluptatem! Voluptatum.
   </body>
-  <script src="./bundle.js"></script>
+  <script src="build/bundle.js"></script>
 </html>

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -10,10 +10,14 @@ app.use(express.static(path.join(__dirname, '../display')));
 
 app.use(bodyParser.json());
 
-app.get('/bundle.js', (req, res) => {
+app.get('/build/bundle.js', (req, res) => {
   console.log('in server.js');
   res.sendFile(path.join(__dirname, '../../build/bundle.js'));
 });
+
+app.use('*', (req, res) => {
+  res.sendStatus(404);
+})
 
 // global error handler
 function errorHandler(err, req, res, next) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,6 @@ module.exports = {
     filename: 'bundle.js'
   },
   devServer: {
-    contentBase: path.join(__dirname, './src/display'),
     publicPath: '/build/',
     proxy: { '/': 'http://localhost:3333' }
   },


### PR DESCRIPTION
Fixed the problem with the dev environment not working with nodemon and webpack. 

Basically, the file paths were incorrect. Since webpack-dev-server serves the bundle through /build (as specified in the webpack.config publicPath option), the request from the index.html page for the bundle must be made through /build/bundle.js. 

I also changed the dev-proxy server back to '/', and then changed the /bundle.js path to /build/bundle.js in server.js to match the change in the index.html file, so that production builds will still work.

I request this boilerplate to be the master branch starting point for the project.