### PR TITLE
watchmo mo now mos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5516,8 +5516,7 @@
     "is-wsl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "isarray": {
       "version": "1.0.0",
@@ -8107,10 +8106,9 @@
       }
     },
     "opn": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
-      "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
+      "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
       "requires": {
         "is-wsl": "^1.1.0"
       }
@@ -12811,6 +12809,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "opn": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+          "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+          "dev": true,
+          "requires": {
+            "is-wsl": "^1.1.0"
+          }
         },
         "readdirp": {
           "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "graphql": "^14.5.8",
     "graphql-syntax-highlighter-react": "^0.4.0",
     "node-sass": "^4.13.1",
+    "opn": "^6.0.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "reactstrap": "^8.4.0",

--- a/src/commands/mo.js
+++ b/src/commands/mo.js
@@ -13,8 +13,9 @@ function mo() {
   fs.copyFile(`${process.cwd()}/src/server/server.js`, `${process.cwd()}/src/server/test-server.js`, err => {
     if (err) console.log(err);
     console.log('Watchmo server firing up....listening on port 3333');
+    let directory = path.join(__dirname, '../server/server.js')
     opn('http://localhost:3333/');
-    const output = execSync(`node ${process.cwd()}/src/server/test-server.js`, { encoding: 'utf-8' });    
+    const output = execSync(`node ${directory}`, { encoding: 'utf-8' });    
   })
 }
 

--- a/src/commands/mo.js
+++ b/src/commands/mo.js
@@ -1,0 +1,21 @@
+//Packages
+const execSync = require('child_process').execSync;
+const fs = require('fs');
+const path = require('path');
+const opn = require('opn');
+
+
+// function mo () { //this will run npm run dev, good for development, bad for production
+//   const output = execSync('npm run dev', { encoding: 'utf-8' });
+// }
+
+function mo() {
+  fs.copyFile(`${process.cwd()}/src/server/server.js`, `${process.cwd()}/src/server/test-server.js`, err => {
+    if (err) console.log(err);
+    console.log('Watchmo server firing up....listening on port 3333');
+    opn('http://localhost:3333/');
+    const output = execSync(`node ${process.cwd()}/src/server/test-server.js`, { encoding: 'utf-8' });    
+  })
+}
+
+module.exports = { mo };


### PR DESCRIPTION
Added two sets of code to Watchmo mo command:

One is commented out, this simply executes npm run dev.
The other will copy the current server code into a testerfile, execute, and open a webpage to the localhost.  This is no dynamic according to the port number in the server file.