### PR TITLE
Less command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 src/watchmoData/parsedData.json
 src/watchmoData/snapshots.txt
-src/commands/less.js

--- a/src/commands/less.js
+++ b/src/commands/less.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+
+/*
+THIS FUNCTION DEPENDS UPON THE FOLLOWING FILE STRUCTURE:
+/src
+|
+-> /commands
+|  |
+|   -> /less.js
+|
+-> /watchmoData
+   |
+   -> /parsedData.json
+   -> /snapshots.txt
+*/
+
+const cleanAllFiles = (pathArray) => {
+  pathArray.forEach(path => {
+    fs.writeFile(path, "", (err) => { if (err) {console.log(err)}})
+  });
+}
+
+
+function less() {
+  const parsedPath = path.join(__dirname, "../watchmoData/parsedData.json");
+  const rawPath = path.join(__dirname, "../watchmoData/snapshots.txt");
+  cleanAllFiles([parsedPath, rawPath]);
+  console.log("FILES CLEAN");
+}
+
+module.exports = {
+  less
+}

--- a/src/commands/mo.js
+++ b/src/commands/mo.js
@@ -42,17 +42,21 @@ function parseData(dataString) {
   return parsed;
 }
 
-function mo(dataPath, savePath) {
-  fs.readFile(dataPath, 'utf8', (err, data) => {
-    if (err) {
-      console.log('Error trying to grab raw Data:', err);
-    } else {
-      saveParsed(parseData(data), savePath);
-    }
-  });
-  let directory = path.join(__dirname, '../server/server.js');
-  exec(`node ${directory}`, { encoding: 'utf-8' });
-  opn('http://localhost:3333/');
+function mo(dataPath, savePath, shouldOpen, noBundle = false) {
+  if (!noBundle) {
+    fs.readFile(dataPath, 'utf8', (err, data) => {
+      if (err) {
+        console.log('Error trying to grab raw Data:', err);
+      } else {
+        saveParsed(parseData(data), savePath);
+      }
+    });
+  }
+  if (shouldOpen) {
+    let directory = path.join(__dirname, '../server/server.js');
+    exec(`node ${directory}`, { encoding: 'utf-8' });
+    opn('http://localhost:3333/');
+  }
 }
 
 

--- a/src/commands/watchmo.js
+++ b/src/commands/watchmo.js
@@ -10,6 +10,7 @@ const path = require('path');
 const { watch } = require('./watch');
 const { cliDefault } = require('./default');
 const { mo } = require('./mo');
+const { less } = require('./less');
 
 //helper functions
 const checkAndGetConfig = configPath => {
@@ -21,6 +22,10 @@ const checkAndGetConfig = configPath => {
 
 //Defining the CLI functionality
 argv
+  .alias({
+    open: "o",
+    bundle: "b"
+  })
   .config(checkAndGetConfig(path.join(__dirname, '../watchmoData/config.json')))
   .command('$0', 'opens up visualizer in browser', cliDefault)
   .command(
@@ -30,7 +35,8 @@ argv
       watch(argv.endpoint, argv.categories, path.join(__dirname, '../watchmoData/snapshots.txt'));
     }
   )
-  .command('mo', 'parses data and opens up visualizer', () => {
-    mo(path.join(__dirname, '../watchmoData/snapshots.txt'), path.join(__dirname, '../watchmoData/parsedData.json'))
+  .command('mo', 'parses data and opens up visualizer', ({argv}) => {
+    mo(path.join(__dirname, '../watchmoData/snapshots.txt'), path.join(__dirname, '../watchmoData/parsedData.json'), argv.open, argv.bundle)
   })
+  .command('less', 'cleans up raw and parsed data', less)
   .help().argv;


### PR DESCRIPTION
**What's new**
- A command `watchmo less` which cleans up your raw and parsed data files.
- The options -open (-o) and -bundle (-b) for the mo command. mo by itself just parses the data. -o opens the server as well, and -b suppresses the bundling command.

**How to use it**

_less_
1. Check that you have watchmo CLI installed by running `watchmo --help`. You should see descriptions for all the commands
2. Check that you have data in your snapshot.txt and parsedData.json files. 
3. Run `watchmo less`. You should see in the console "FILES CLEANED". 
4. Check to see that your snapshot.txt and parsedData.json files are empty.

_mo options_
1. Check that you have watchmo CLI installed by running `watchmo --help`. You should see descriptions for all the commands.
2. Check that you have data in your snapshot.txt file. 
3. Delete your parsedData.json file if it exists.
4. Run `watchmo mo`. You should see in the console "DATA BUNDLED" and the server should _not_ open. You should also see your parsedData.json file reappear.
5. Run `watchmo mo -o -b`. You should see nothing in the console, and the server should open. 

**Why?**
- Less makes it easy to start over when you change the config file.
- mo -o -b is good when you haven't changed the data in snapshots.txt but want to open the server. It saves having to parse through the large snapshot.txt again. 
- mo not opening the server by default is nice for development, and provides more flexibility for the command. 